### PR TITLE
Add image/image value

### DIFF
--- a/chart/templates/backtesting.yaml
+++ b/chart/templates/backtesting.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if .Values.backtesting.download_data }}
       initContainers:
       - name: download-data
-        image: freqtradeorg/freqtrade:{{ .Values.image.tag }}
+        image: {{ .Values.image.image }}:{{ .Values.image.tag }}
         command:
         - freqtrade
         args:
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: backtesting
-        image: freqtradeorg/freqtrade:{{ .Values.image.tag }}
+        image: {{ .Values.image.image }}:{{ .Values.image.tag }}
         command:
         - freqtrade
         args:

--- a/chart/templates/backtesting.yaml
+++ b/chart/templates/backtesting.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if .Values.backtesting.download_data }}
       initContainers:
       - name: download-data
-        image: {{ .Values.image.image }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.base }}:{{ .Values.image.tag }}
         command:
         - freqtrade
         args:
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: backtesting
-        image: {{ .Values.image.image }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.base }}:{{ .Values.image.tag }}
         command:
         - freqtrade
         args:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: freqtrade
-        image: freqtradeorg/freqtrade:{{ .Values.image.tag }}
+        image: {{ .Values.image.image }}:{{ .Values.image.tag }}
         command:
         - freqtrade
         args:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: freqtrade
-        image: {{ .Values.image.image }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.base }}:{{ .Values.image.tag }}
         command:
         - freqtrade
         args:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,6 +72,7 @@ config:
     process_throttle_secs: 5
 
 image:
+  image: freqtradeorg/freqtrade
   tag: latest
 
 backtesting:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,7 +72,7 @@ config:
     process_throttle_secs: 5
 
 image:
-  image: freqtradeorg/freqtrade
+  base: freqtradeorg/freqtrade
   tag: latest
 
 backtesting:


### PR DESCRIPTION
Useful if you want to use custom docker images. Used in cases where you install extra requirements on top of the base freqtrade image.